### PR TITLE
Update tyon_aloitus.md

### DIFF
--- a/web/tyon_aloitus.md
+++ b/web/tyon_aloitus.md
@@ -14,8 +14,6 @@ Harjoitustyön ohjelmointikieli on Java.
 
 Web-sovelluksia kurssilla ei sallita. Sovelluksissa sallitaan toki webissä olevat komponentit, mutta sovelluksen käyttöliittymän tulee olla ns. desktop-sovellus.
 
-Muuta kuin Javaa käytettäessä ohjaus saattaa olla "huonompaa", sillä kurssihenkilökunnan kokemus vaihtoehtoisilla kielillä tehtävistä desktop-sovelluksista on rajallinen.
-
 **Ohjelmakoodin muuttujat, luokat ja metodit kirjoitetaan englanniksi.** Dokumentaatio voidaan kirjoittaa joko suomeksi tai englanniksi. 
 
 ## Ohjelman toteutus


### PR DESCRIPTION
Viitaten tämänpäiväiseen Telegram-keskusteluun, tässä poistamani kohta oli se, josta sain käsityksen, että Java olisi lähtökohtaisesti kurssin kieli, mutta saisi tehdä muullakin, kun tekstissä puhutaan muiden kielien ohjauksesta. Eihän tuota tarvitse sinänsä kokonaan poistaa, mutta sanamuotoa voisi muokata enemmän Javan valintaa perustelevaksi.